### PR TITLE
run exec as first step to allow dynamic schema

### DIFF
--- a/lib/schema-inspector.js
+++ b/lib/schema-inspector.js
@@ -199,6 +199,18 @@
 
 // Validation ------------------------------------------------------------------
 	var _validationAttribut = {
+		exec: function (schema, candidate, callback) {
+			var self = this;
+
+			if (typeof callback === 'function') {
+				return this.asyncExec(schema, candidate, callback);
+			}
+			(_typeIs.array(schema.exec) ? schema.exec : [schema.exec]).forEach(function (exec) {
+				if (typeof exec === 'function') {
+					exec.call(self, schema, candidate);
+				}
+			});
+		},
 		optional: function (schema, candidate) {
 			var opt = typeof schema.optional === 'boolean' ? schema.optional : (schema.optional === 'true'); // Default is false
 
@@ -417,18 +429,6 @@
 					self.report(msg);
 				}
 			}
-		},
-		exec: function (schema, candidate, callback) {
-			var self = this;
-
-			if (typeof callback === 'function') {
-				return this.asyncExec(schema, candidate, callback);
-			}
-			(_typeIs.array(schema.exec) ? schema.exec : [schema.exec]).forEach(function (exec) {
-				if (typeof exec === 'function') {
-					exec.call(self, schema, candidate);
-				}
-			});
 		},
 		properties: function (schema, candidate, callback) {
 			if (typeof callback === 'function') {
@@ -829,6 +829,19 @@
 	// Every function return the future value of each property. Therefore you
 	// have to return post even if you do not change its value
 	var _sanitizationAttribut = {
+		exec: function (schema, post, callback) {
+			if (typeof callback === 'function') {
+				return this.asyncExec(schema, post, callback);
+			}
+			var execs = _typeIs.array(schema.exec) ? schema.exec : [schema.exec];
+
+			execs.forEach(function (exec) {
+				if (typeof exec === 'function') {
+					post = exec.call(this, schema, post);
+				}
+			}, this);
+			return post;
+		},
 		strict: function (schema, post) {
 			if (typeof schema.strict === 'string') { schema.strict = (schema.strict === 'true'); }
 			if (schema.strict !== true)
@@ -1015,19 +1028,6 @@
 					this._back();
 				}
 			}
-			return post;
-		},
-		exec: function (schema, post, callback) {
-			if (typeof callback === 'function') {
-				return this.asyncExec(schema, post, callback);
-			}
-			var execs = _typeIs.array(schema.exec) ? schema.exec : [schema.exec];
-
-			execs.forEach(function (exec) {
-				if (typeof exec === 'function') {
-					post = exec.call(this, schema, post);
-				}
-			}, this);
 			return post;
 		}
 	};

--- a/test/validation_test.js
+++ b/test/validation_test.js
@@ -2125,4 +2125,38 @@ exports.validation = function () {
 
 	});
 
+
+	suite('schema #23 (dynamic change by exec / add a property)', function () {
+		var schema = {
+			type: 'object',
+			strict: true,
+			properties: {
+				key1: {type: 'string', optional: true}
+			},
+			exec: function (schema) {
+				//I can add dynamically a required property
+				schema.properties.key2 = {type: 'string', optional: false}
+			}
+		};
+
+		test('candidate #1 : a new dynamically added required property is checked', function () {
+			var candidate = {};
+			var result = si.validate(schema, candidate);
+			result.should.be.an.Object;
+			result.should.have.property('valid').with.equal(false);
+			result.should.have.property('error').with.be.an.instanceof(Array).and.be.lengthOf(1);
+			result.error[0].property.should.equal('@.key2');
+		});
+
+
+		test('candidate #2 : strict take account of dynamically changed schema', function () {
+			var candidate = {key2: "1"};
+			var result = si.validate(schema, candidate);
+			result.should.be.an.Object;
+			result.should.have.property('valid').with.equal(true);
+		});
+
+	});
+
+
 };


### PR DESCRIPTION
set exec as the first attribute to make exec the first Validation/Sanitization step.
By this way, all the schema could be modified by the exec Fn (not only properties & items for instance)
